### PR TITLE
Get Token Expiry Working

### DIFF
--- a/src/ClusterView.svelte
+++ b/src/ClusterView.svelte
@@ -28,8 +28,8 @@
 		token.unsubscribe(id);
 	});
 
-	async function changeToken(value) {
-		if (value == null) {
+	async function changeToken(value, scope) {
+		if (value == null || scope == token.unscoped) {
 			reset();
 			return;
 		}

--- a/src/ControlPlaneView.svelte
+++ b/src/ControlPlaneView.svelte
@@ -25,8 +25,8 @@
 	});
 
 	// TODO: this is copied in the cluster view, we should cache and share.
-	async function changeToken(value) {
-		if (value == null) {
+	async function changeToken(value, scope) {
+		if (value == null || scope == token.unscoped) {
 			reset();
 			return;
 		}

--- a/src/LoginModal.svelte
+++ b/src/LoginModal.svelte
@@ -40,7 +40,7 @@
 
 			const result = await response.json();
 
-			token.set(result.token);
+			token.set(result.token, token.unscoped);
 		} catch (e) {
 			console.log(e);
 		}

--- a/src/credentials.js
+++ b/src/credentials.js
@@ -11,30 +11,42 @@ export function writable(key) {
 	// Keep a set of subscribers.
 	const subscribers = new Map();
 
+	// Provide some constants so we know what type of token this is.
+	let scope = null;
+
+	let scoped = Symbol();
+	let unscoped = Symbol();
+
 	// get gets the initial value.
 	function get() {
 		return value;
 	}
 
 	// set sets the value and notifies all subscribers.
-	function set(new_value) {
+	function set(new_value, kind) {
 		value = new_value;
+		scope = kind;
 
 		if (browser) {
 			window.sessionStorage.setItem(key, value);
 		}
 
 		subscribers.forEach((run) => {
-			run(value);
+			run(value, scope);
 		});
 	}
 
 	// remove unsets the session storage and notifies subscribers.
 	function remove() {
-		window.sessionStorage.removeItem(key);
+		value = null;
+		scope = null;
+
+		if (browser) {
+			window.sessionStorage.removeItem(key);
+		}
 
 		subscribers.forEach((run) => {
-			run(value);
+			run(value, scope);
 		});
 	}
 
@@ -45,7 +57,7 @@ export function writable(key) {
 
 		// Only notify the subscriber of an initial value if there is one.
 		if (value != null) {
-			run(value);
+			run(value, scope);
 		}
 	}
 
@@ -54,7 +66,7 @@ export function writable(key) {
 		subscribers.delete(id);
 	}
 
-	return { get, set, remove, subscribe, unsubscribe };
+	return { get, set, remove, subscribe, unsubscribe, scoped, unscoped };
 }
 
 // token is the main token storage.


### PR DESCRIPTION
Most of the way there.  Add in any missing HTTP status error handling. Add in a scope to token management, this is so when we're logged out, a subscriber e.g. control planes, doesn't immediately hit a 401 on login before the scoping handler has done its job, and log you straight back out again!