### PR TITLE
Add Workload Pool AZ Support

### DIFF
--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -365,6 +365,7 @@
 					version: version,
 					imageName: wp.image.name,
 					flavorName: wp.flavor.name,
+					availabilityZone: wp.computeAZ.name,
 					disk: {
 						size: wp.disk
 					}
@@ -575,6 +576,7 @@
 					{autoscaling}
 					{flavors}
 					{images}
+					{computeAZs}
 					bind:object={pool}
 					on:workload-update={updateCost}
 				/>

--- a/src/lib/WorkloadPoolCreate.svelte
+++ b/src/lib/WorkloadPoolCreate.svelte
@@ -6,6 +6,7 @@
 	export let autoscaling;
 	export let flavors;
 	export let images;
+	export let computeAZs;
 
 	let name = null;
 	let image = null;
@@ -16,6 +17,7 @@
 	let maxReplicas = 3;
 	let labels = null;
 	let disk = 50;
+	let computeAZ = null;
 
 	// Roll up all the parameters in an easy to use/bind variable.
 	// On an update to any of the variables, update the object/any bindings
@@ -32,7 +34,8 @@
 			minReplicas: minReplicas,
 			maxReplicas: maxReplicas,
 			labels: labels,
-			disk: disk
+			disk: disk,
+			computeAZ: computeAZ
 		};
 
 		dispatch('workload-update', {});
@@ -44,6 +47,9 @@
 	}
 	$: if (flavor == null && flavors.length != 0) {
 		flavor = flavors[0];
+	}
+	$: if (computeAZ == null && computeAZs.length != 0) {
+		computeAZ = computeAZs[0];
 	}
 </script>
 
@@ -110,6 +116,13 @@
 	<input id="labels" type="text" placeholder="key1=value1,key2=value2" bind:value={labels} />
 	<label for="labels">Comma separated set of labels to apply to Kubernetes nodes on creation.</label
 	>
+
+	<select id="computeAZ" bind:value={computeAZ} required>
+		{#each computeAZs as a}
+			<option value={a}>{a.name}</option>
+		{/each}
+	</select>
+	<label for="image">Availability zone to provision the pool in.</label>
 </details>
 
 <style>


### PR DESCRIPTION
Rather than being lazy and just picking the accidental default "nova" which encompasses all PODs, allow selection.  Today, POD-1 became available, however cannot schedule GPU flavors in there, so we need to allow explicit selection to actually do any work!  This raises a bigger question, can we make a service that can do the admin level jazz to work out what flavours can be scheduled on what AZs and make the selection inteligent?