### PR TITLE
Add Control Plane Versioning

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -135,3 +135,11 @@ export function getClusterKubeconfig(controlPlane, cluster, opts) {
 export function deleteCluster(controlPlane, cluster, opts) {
 	return request('DELETE', `/api/v1/controlplanes/${controlPlane}/clusters/${cluster}`, opts);
 }
+
+export function listApplicationBundlesControlPlane(opts) {
+	return request('GET', '/api/v1/applicationBundles/controlPlane', opts);
+}
+
+export function listApplicationBundlesCluster(opts) {
+	return request('GET', '/api/v1/applicationBundles/cluster', opts);
+}


### PR DESCRIPTION
Add a read of application bundles on control plane view mount, select a sane default based on preview/EOL status, add in a UI element to allow selection and pass the selected value back.