### PR TITLE
Remove Logo Padding from Login

### DIFF
--- a/src/lib/LoginModal.svelte
+++ b/src/lib/LoginModal.svelte
@@ -84,7 +84,7 @@
 	}
 
 	.login-modal-header > img {
-		padding: 2em 5em;
+		padding: 2em 0;
 		width: 15em;
 		max-width: 20em;
 	}


### PR DESCRIPTION
Unnecessary left/right padding was causing an overflow and scrolling.