### PR TITLE
Use New CP/CL Interfaces

### DIFF
--- a/src/lib/ClusterView.svelte
+++ b/src/lib/ClusterView.svelte
@@ -166,8 +166,9 @@
 </script>
 
 <CreateClusterModal
-	bind:active={createModalActive}
 	{controlPlane}
+	{clusters}
+	bind:active={createModalActive}
 	on:clusterCreated={clusterCreated}
 />
 
@@ -214,7 +215,7 @@
 				<dt>Status:</dt>
 				<dd>{cl.status.status}</dd>
 				<dt>Version:</dt>
-				<dd>{cl.applicationBundle}</dd>
+				<dd>{cl.applicationBundle.version}</dd>
 				<dt>Kubernetes:</dt>
 				<dd>{cl.controlPlane.version}</dd>
 			</dl>

--- a/src/lib/ControlPlaneView.svelte
+++ b/src/lib/ControlPlaneView.svelte
@@ -100,6 +100,7 @@
 </script>
 
 <CreateControlPlaneModal
+	{controlPlanes}
 	bind:active={createModalActive}
 	on:controlPlaneCreated={controlPlaneCreated}
 />
@@ -150,7 +151,7 @@
 			<dt>Status:</dt>
 			<dd>{cp.status.status}</dd>
 			<dt>Version:</dt>
-			<dd>{cp.applicationBundle}</dd>
+			<dd>{cp.applicationBundle.version}</dd>
 		</dl>
 	</article>
 {/each}


### PR DESCRIPTION
Server will now expand application bundle names from the CRs into full on objects, so you can just copy from the AB list directly into the create struct.  Also took the liberty of playing about with validation some more, especially reactive declarations.  Mostly the end goal was detecting and validating naming collisions.