### PR TITLE
UX Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spec:
   source:
     path: charts/unikorn-ui
     repoURL: git@github.com:eschercloudai/unikorn-ui
-    targetRevision: 0.1.7
+    targetRevision: 0.1.8
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn-ui/Chart.yaml
+++ b/charts/unikorn-ui/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: 0.1.7
-appVersion: 0.1.7
+version: 0.1.8
+appVersion: 0.1.8
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/src/lib/ClusterView.svelte
+++ b/src/lib/ClusterView.svelte
@@ -161,8 +161,14 @@
 	// Define the per-control plane drop down menu.
 	let dropdownItems = [
 		{ id: 'detail', value: 'Details', icon: 'bx:detail', handler: handleDetails },
-		{ id: 'kubeconfig', value: 'Kubeconfig', icon: 'mdi:kubernetes', handler: handleKubeconfig },
-		{ id: 'edit', value: 'Edit', icon: 'bx:edit', handler: handleEdit },
+		{
+			id: 'kubeconfig',
+			value: 'Kubeconfig',
+			icon: 'mdi:kubernetes',
+			handler: handleKubeconfig,
+			disablable: true
+		},
+		{ id: 'edit', value: 'Edit', icon: 'bx:edit', handler: handleEdit, disablable: true },
 		{ id: 'delete', value: 'Delete', icon: 'bx:trash', handler: handleDelete }
 	];
 
@@ -225,7 +231,12 @@
 				<div class="name">{cl.status.name}</div>
 			</div>
 			<div class="widgets">
-				<DropDownIcon icon="mdi:dots-vertical" resource={cl} items={dropdownItems} />
+				<DropDownIcon
+					icon="mdi:dots-vertical"
+					resource={cl}
+					items={dropdownItems}
+					disabled={cl.status.status != 'Provisioned'}
+				/>
 			</div>
 			<dl>
 				<dt>Age:</dt>

--- a/src/lib/ControlPlaneView.svelte
+++ b/src/lib/ControlPlaneView.svelte
@@ -97,7 +97,7 @@
 	// Define the per-control plane drop down menu.
 	let dropdownItems = [
 		{ id: 'detail', value: 'Details', icon: 'bx:detail', handler: handleDetails },
-		{ id: 'edit', value: 'Edit', icon: 'bx:edit', handler: handleEdit },
+		{ id: 'edit', value: 'Edit', icon: 'bx:edit', handler: handleEdit, disablable: true },
 		{ id: 'delete', value: 'Delete', icon: 'bx:trash', handler: handleDelete }
 	];
 
@@ -161,7 +161,12 @@
 			<div class="name">{cp.status.name}</div>
 		</div>
 		<div class="widgets">
-			<DropDownIcon icon="mdi:dots-vertical" resource={cp} items={dropdownItems} />
+			<DropDownIcon
+				icon="mdi:dots-vertical"
+				resource={cp}
+				items={dropdownItems}
+				disabled={cp.status.status != 'Provisioned'}
+			/>
 		</div>
 		<dl>
 			<dt>Age:</dt>

--- a/src/lib/DropDownIcon.svelte
+++ b/src/lib/DropDownIcon.svelte
@@ -13,6 +13,9 @@
 	//   value: value of the menu item (aka text)
 	export let items = [];
 
+	// disabled propagates this to individual items.
+	export let disabled = false;
+
 	let active = false;
 
 	function show() {
@@ -36,7 +39,7 @@
 		<div class="dropdown-menu" class:active use:clickOutside on:click_outside={hide}>
 			<ul>
 				{#each items as item}
-					<DropDownItem on:select={selected} {item}>
+					<DropDownItem on:select={selected} {item} {disabled}>
 						<iconify-icon icon={item.icon} />
 						<div>{item.value}</div>
 					</DropDownItem>

--- a/src/lib/DropDownItem.svelte
+++ b/src/lib/DropDownItem.svelte
@@ -4,18 +4,29 @@
 	// id is a unique identifier within the menu.
 	export let item;
 
+	// disabled allows the parent to control when the item is clickable.
+	export let disabled;
+
+	$: itemDisabled = item.disablable && disabled;
+
 	const dispatch = createEventDispatcher();
 
 	function click() {
-		dispatch('select', item);
+		if (!itemDisabled) {
+			dispatch('select', item);
+		}
 	}
 </script>
 
-<li class="selectable" on:click={click} on:keypress={click}>
+<li class="selectable" class:disabled={itemDisabled} on:click={click} on:keypress={click}>
 	<slot />
 </li>
 
 <style>
+	.disabled {
+		cursor: not-allowed;
+		color: var(--mid-grey);
+	}
 	li {
 		display: flex;
 		align-items: center;

--- a/src/lib/EditClusterModal.svelte
+++ b/src/lib/EditClusterModal.svelte
@@ -311,6 +311,8 @@
 		token.unsubscribe(id);
 	});
 
+	let loaded = false;
+
 	// When we get a token
 	async function updateAll() {
 		const t = token.get();
@@ -319,13 +321,17 @@
 			return;
 		}
 
-		updateKeyPairs(t);
-		updateImages(t);
-		updateFlavors(t);
-		updateComputeAZs(t);
-		updateBlockStorageAZs(t);
-		updateExternalNetworks(t);
-		updateApplicationBundles(t);
+		await Promise.all([
+			updateKeyPairs(t),
+			updateImages(t),
+			updateFlavors(t),
+			updateComputeAZs(t),
+			updateBlockStorageAZs(t),
+			updateExternalNetworks(t),
+			updateApplicationBundles(t)
+		]);
+
+		loaded = true;
 	}
 
 	// Roll up validity to enable creation.
@@ -442,167 +448,172 @@
 </script>
 
 <Modal {active} fixed="true">
-	<form>
-		<h1>Edit Cluster</h1>
-		<dl>
-			<dt>Name</dt>
-			<dd>{controlPlane.name}</dd>
-		</dl>
+	{#if loaded}
+		<form>
+			<h1>Edit Cluster</h1>
+			<dl>
+				<dt>Name</dt>
+				<dd>{controlPlane.name}</dd>
+			</dl>
 
-		<details>
-			<summary>Lifecycle (Advanced)</summary>
+			<details>
+				<summary>Lifecycle (Advanced)</summary>
 
-			<p>
-				The platform will automatically upgrade clusters to provide confidence in security, and
-				periodically enable new features. This section describes those defaults and, where
-				applicable, allows you to fine tune those settings.
-			</p>
+				<p>
+					The platform will automatically upgrade clusters to provide confidence in security, and
+					periodically enable new features. This section describes those defaults and, where
+					applicable, allows you to fine tune those settings.
+				</p>
 
-			<select id="appbundle" bind:value={applicationBundle}>
-				{#each applicationBundles as b}
-					{#if b.preview}
-						<option value={b}>{b.version} (Preview)</option>
-					{:else if b.endOfLife}
-						<option value={b}>{b.version} (End-of-Life {b.endOfLife})</option>
+				<select id="appbundle" bind:value={applicationBundle}>
+					{#each applicationBundles as b}
+						{#if b.preview}
+							<option value={b}>{b.version} (Preview)</option>
+						{:else if b.endOfLife}
+							<option value={b}>{b.version} (End-of-Life {b.endOfLife})</option>
+						{:else}
+							<option value={b}>{b.version}</option>
+						{/if}
+					{/each}
+				</select>
+				<label for="appbundle">
+					Selects the cluster version. Versions marked as <em>Preview</em> are early release
+					candidates, and may have undergone less rigorous testing. Versions marked
+					<em>End-of-Life</em> indicate the date when they will be automatically upgraded by the platform.
+				</label>
+			</details>
+
+			<details>
+				<summary>Topology (Advanced)</summary>
+
+				<select id="compute-az" bind:value={computeAZ}>
+					{#each computeAZs as az}
+						<option value={az}>{az.name}</option>
+					{/each}
+				</select>
+				<label for="compute-az">
+					Select the global availability zone for compute instances. You can override this on a
+					per-workload pool basis to improve cluster availability.
+				</label>
+			</details>
+
+			<details>
+				<summary>Networking (Advanced)</summary>
+
+				<p>
+					Network settings are optional, and if not specified will yield stable and scalable
+					defaults.
+				</p>
+				<p>
+					It is possible to connect Kubernetes clusters together with virtual private networks
+					(VPNs). While this is discouraged, you must ensure that network CIDRs are globally unique
+					and do not overlap.
+				</p>
+
+				<select id="keypair" bind:value={keyPair}>
+					<option value={null}>(None)</option>
+					{#each keyPairs as k}
+						<option value={k}>{k.name}</option>
+					{/each}
+				</select>
+				<label for="keypair">
+					SSH key pair to include on each node. It is advised this not be used to improve security.
+				</label>
+
+				<input
+					id="allowedPrefixes"
+					type="text"
+					placeholder="1.2.3.4/32,7.8.0.0/16"
+					bind:value={allowedPrefixes}
+				/>
+				<label for="allowedPrefixes">
+					Comma separated list of IPv4 CIDR blocks to permit access to the Kubernetes API.
+				</label>
+			</details>
+
+			<h2>Control Plane</h2>
+
+			<select id="version" bind:value={version} required>
+				{#each versions as v}
+					<option value={v}>{v}</option>
+				{/each}
+			</select>
+			<label for="version">Kubernetes version to provision with.</label>
+
+			<select id="image" bind:value={image} required>
+				{#each images as i}
+					<option value={i}>{i.name}</option>
+				{/each}
+			</select>
+			<label for="image">Virtual machine image to use.</label>
+
+			<select id="flavor" bind:value={flavor} required>
+				{#each cpFlavors as f}
+					{#if f.gpus}
+						<option value={f}>{f.name} ({f.cpus} core, {f.memory}Gi, {f.gpus} GPU)</option>
 					{:else}
-						<option value={b}>{b.version}</option>
+						<option value={f}>{f.name} ({f.cpus} core, {f.memory}Gi)</option>
 					{/if}
 				{/each}
 			</select>
-			<label for="appbundle">
-				Selects the cluster version. Versions marked as <em>Preview</em> are early release
-				candidates, and may have undergone less rigorous testing. Versions marked
-				<em>End-of-Life</em> indicate the date when they will be automatically upgraded by the platform.
-			</label>
-		</details>
-
-		<details>
-			<summary>Topology (Advanced)</summary>
-
-			<select id="compute-az" bind:value={computeAZ}>
-				{#each computeAZs as az}
-					<option value={az}>{az.name}</option>
-				{/each}
-			</select>
-			<label for="compute-az">
-				Select the global availability zone for compute instances. You can override this on a
-				per-workload pool basis to improve cluster availability.
-			</label>
-		</details>
-
-		<details>
-			<summary>Networking (Advanced)</summary>
-
-			<p>
-				Network settings are optional, and if not specified will yield stable and scalable defaults.
-			</p>
-			<p>
-				It is possible to connect Kubernetes clusters together with virtual private networks (VPNs).
-				While this is discouraged, you must ensure that network CIDRs are globally unique and do not
-				overlap.
-			</p>
-
-			<select id="keypair" bind:value={keyPair}>
-				<option value={null}>(None)</option>
-				{#each keyPairs as k}
-					<option value={k}>{k.name}</option>
-				{/each}
-			</select>
-			<label for="keypair">
-				SSH key pair to include on each node. It is advised this not be used to improve security.
-			</label>
-
-			<input
-				id="allowedPrefixes"
-				type="text"
-				placeholder="1.2.3.4/32,7.8.0.0/16"
-				bind:value={allowedPrefixes}
-			/>
-			<label for="allowedPrefixes">
-				Comma separated list of IPv4 CIDR blocks to permit access to the Kubernetes API.
-			</label>
-		</details>
-
-		<h2>Control Plane</h2>
-
-		<select id="version" bind:value={version} required>
-			{#each versions as v}
-				<option value={v}>{v}</option>
-			{/each}
-		</select>
-		<label for="version">Kubernetes version to provision with.</label>
-
-		<select id="image" bind:value={image} required>
-			{#each images as i}
-				<option value={i}>{i.name}</option>
-			{/each}
-		</select>
-		<label for="image">Virtual machine image to use.</label>
-
-		<select id="flavor" bind:value={flavor} required>
-			{#each cpFlavors as f}
-				{#if f.gpus}
-					<option value={f}>{f.name} ({f.cpus} core, {f.memory}Gi, {f.gpus} GPU)</option>
-				{:else}
-					<option value={f}>{f.name} ({f.cpus} core, {f.memory}Gi)</option>
-				{/if}
-			{/each}
-		</select>
-		<label for="flavor">Virtual machine type to use.</label>
-
-		<div class="slider">
-			<input id="disk" type="range" min="50" max="2000" step="50" bind:value={disk} />
-			<span>{disk}GiB</span>
-		</div>
-		<label for="disk">The size of the root disk.</label>
-
-		<details>
-			<summary>Advanced Options</summary>
+			<label for="flavor">Virtual machine type to use.</label>
 
 			<div class="slider">
-				<input id="replicas" type="range" min="1" max="9" step="2" bind:value={replicas} />
-				<span>{replicas}</span>
+				<input id="disk" type="range" min="50" max="2000" step="50" bind:value={disk} />
+				<span>{disk}GiB</span>
 			</div>
-			<label for="replicas">
-				Number of virtual machines. The default (3) is generally cost effective while providing
-				high-availability.
-			</label>
-		</details>
+			<label for="disk">The size of the root disk.</label>
 
-		<h2>Workload Pools</h2>
+			<details>
+				<summary>Advanced Options</summary>
 
-		{#each workloadPools as pool, index}
-			<section>
-				<WorkloadPoolEdit
-					existing={pool.existing}
-					{flavors}
-					{images}
-					{computeAZs}
-					bind:object={pool.object}
-				/>
-				<button on:click={() => removePool(index)}>
-					<iconify-icon icon="mdi:delete" />
-					<div>Remove Pool</div>
+				<div class="slider">
+					<input id="replicas" type="range" min="1" max="9" step="2" bind:value={replicas} />
+					<span>{replicas}</span>
+				</div>
+				<label for="replicas">
+					Number of virtual machines. The default (3) is generally cost effective while providing
+					high-availability.
+				</label>
+			</details>
+
+			<h2>Workload Pools</h2>
+
+			{#each workloadPools as pool, index}
+				<section>
+					<WorkloadPoolEdit
+						existing={pool.existing}
+						{flavors}
+						{images}
+						{computeAZs}
+						bind:object={pool.object}
+					/>
+					<button on:click={() => removePool(index)}>
+						<iconify-icon icon="mdi:delete" />
+						<div>Remove Pool</div>
+					</button>
+				</section>
+			{/each}
+
+			<button on:click={addPool}>
+				<iconify-icon icon="material-symbols:add" />
+				<div>Add New Pool</div>
+			</button>
+
+			<div class="buttons">
+				<button type="submit" disabled={!valid} on:click={submit} on:keydown={submit}>
+					<iconify-icon icon="mdi:tick" />
+					<div>Submit</div>
 				</button>
-			</section>
-		{/each}
-
-		<button on:click={addPool}>
-			<iconify-icon icon="material-symbols:add" />
-			<div>Add New Pool</div>
-		</button>
-
-		<div class="buttons">
-			<button type="submit" disabled={!valid} on:click={submit} on:keydown={submit}>
-				<iconify-icon icon="mdi:tick" />
-				<div>Submit</div>
-			</button>
-			<button on:click={close} on:keydown={close}>
-				<iconify-icon icon="mdi:close" />
-				<div>Cancel</div>
-			</button>
-		</div>
-	</form>
+				<button on:click={close} on:keydown={close}>
+					<iconify-icon icon="mdi:close" />
+					<div>Cancel</div>
+				</button>
+			</div>
+		</form>
+	{:else}
+		<h3>Loading ...</h3>
+	{/if}
 </Modal>
 
 <style>

--- a/src/lib/WorkloadPoolCreate.svelte
+++ b/src/lib/WorkloadPoolCreate.svelte
@@ -17,6 +17,8 @@
 	let computeAZ = null;
 
 	// Set defaults when they are available.
+	// TODO: the image list will change when the version does, so this
+	// doesn't work properly.
 	$: if (image == null && images.length != 0) {
 		image = images[0];
 	}

--- a/src/lib/WorkloadPoolEdit.svelte
+++ b/src/lib/WorkloadPoolEdit.svelte
@@ -33,7 +33,9 @@
 		}
 
 		if (existing.labels) {
-			labels = existing.labels.keys.map((x) => `${x}=${existing.labels[x]}`).join(',');
+			labels = Object.keys(existing.labels)
+				.map((x) => `${x}=${existing.labels[x]}`)
+				.join(',');
 		}
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -318,12 +318,13 @@
 		padding: 0;
 	}
 	:global(ul li) {
-		color: var(--mid-grey);
+		color: var(--dark-grey);
 		padding: var(--padding);
 		list-style: none;
+		transition: all 0.3s ease-in-out;
 	}
 	:global(ul li:hover) {
-		color: var(--dark-grey);
+		color: black;
 		background-color: var(--light-grey);
 	}
 	:global(ul li iconify-icon:first-child) {


### PR DESCRIPTION
When loading things like the create/edit cluster menu that require "long" pre-load times, mask this by waiting on a promise all, and only then render the form, display a loading screen before then.  Also make dropdowns diablable until the cluster is provisioned.  There are certain things that are a bit broken, like you can still delete when it's being deleted, but :shrug:.