### PR TITLE
Upgradable Foundations

### DIFF
--- a/src/lib/ClusterView.svelte
+++ b/src/lib/ClusterView.svelte
@@ -245,9 +245,13 @@
 				<dd>{cl.status.status}</dd>
 				<dt>Version:</dt>
 				{#if cl.applicationBundle.preview}
-					<dd>{cl.applicationBundle.version} (Preview)</dd>
+					<dd>{cl.applicationBundle.version} <span class="detail">Preview</span></dd>
 				{:else if cl.applicationBundle.endOfLife}
-					<dd>{cl.applicationBundle.version} (End-of-Life {cl.applicationBundle.endOfLife})</dd>
+					<dd>
+						{cl.applicationBundle.version}
+						<span class="detail">EOL {new Date(cl.applicationBundle.endOfLife).toDateString()}</span
+						>
+					</dd>
 				{:else}
 					<dd>{cl.applicationBundle.version}</dd>
 				{/if}
@@ -307,6 +311,10 @@
 	}
 	dd {
 		margin: 0;
+	}
+	dd span.detail {
+		font-size: 0.75rem;
+		color: var(--mid-grey);
 	}
 	@media only screen and (min-width: 720px) {
 		article {

--- a/src/lib/ControlPlaneView.svelte
+++ b/src/lib/ControlPlaneView.svelte
@@ -175,9 +175,12 @@
 			<dd>{cp.status.status}</dd>
 			<dt>Version:</dt>
 			{#if cp.applicationBundle.preview}
-				<dd>{cp.applicationBundle.version} (Preview)</dd>
+				<dd>{cp.applicationBundle.version} <span class="detail">Preview)</span></dd>
 			{:else if cp.applicationBundle.endOfLife}
-				<dd>{cp.applicationBundle.version} (End-of-Life {cp.applicationBundle.endOfLife})</dd>
+				<dd>
+					{cp.applicationBundle.version}
+					<span class="detail">EOL {cp.applicationBundle.endOfLife}</span>
+				</dd>
 			{:else}
 				<dd>{cp.applicationBundle.version}</dd>
 			{/if}
@@ -224,6 +227,10 @@
 	}
 	dd {
 		margin: 0;
+	}
+	dd span.detail {
+		font-size: 0.75rem;
+		color: var(--mid-grey);
 	}
 	@media only screen and (min-width: 720px) {
 		article {

--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -287,7 +287,8 @@
 		}
 
 		// These are returned in ascending order, we want latest first.
-		applicationBundles = result.reverse();
+		// Also don't allow users to create new end-of-life resources.
+		applicationBundles = result.reverse().filter((x) => !x.endOfLife);
 	}
 
 	// Update the selected application bundle when the bundles list updates.

--- a/src/lib/CreateControlPlaneModal.svelte
+++ b/src/lib/CreateControlPlaneModal.svelte
@@ -70,7 +70,8 @@
 		}
 
 		// These are returned in ascending order, we want latest first.
-		applicationBundles = result.reverse();
+		// Also don't allow users to create new end-of-life resources.
+		applicationBundles = result.reverse().filter((x) => !x.endOfLife);
 	}
 
 	// Update the selected application bundle when the bundles list updates.

--- a/src/lib/EditClusterModal.svelte
+++ b/src/lib/EditClusterModal.svelte
@@ -298,7 +298,11 @@
 		}
 
 		// These are returned in ascending order, we want latest first.
-		applicationBundles = result.reverse();
+		// Don't display end-of-life bundles, unless the existing one is
+		// marked EOL.
+		applicationBundles = result
+			.reverse()
+			.filter((x) => !x.endOfLife || x.name == cluster.applicationBundle.name);
 	}
 
 	// id is a unique identifier for the component instance.

--- a/src/lib/EditControlPlaneModal.svelte
+++ b/src/lib/EditControlPlaneModal.svelte
@@ -60,7 +60,11 @@
 		}
 
 		// These are returned in ascending order, we want latest first.
-		applicationBundles = result.reverse();
+		// Don't display end-of-life bundles, unless the existing one is
+		// marked EOL.
+		applicationBundles = result
+			.reverse()
+			.filter((x) => !x.endOfLife || x.name == controlPlane.applicationBundle.name);
 	}
 
 	$: if (!applicationBundle && controlPlane && applicationBundles.length > 0) {


### PR DESCRIPTION
When an bundle is EOL, don't allow people to deploy with it (because why?).  Filter upgrades so they only consider non-EOL images, unless it's an existing one pending upgrade.