### PR TITLE
Auto Upgrade Editing

### DIFF
--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -108,13 +108,13 @@
 	let autoUpgradeDaysOfWeek = false;
 
 	let daysOfTheWeekWindows = {
-		Sunday: {},
-		Monday: {},
-		Tuesday: {},
-		Wednesday: {},
-		Thursday: {},
-		Friday: {},
-		Saturday: {}
+		sunday: {},
+		monday: {},
+		tuesday: {},
+		wednesday: {},
+		thursday: {},
+		friday: {},
+		saturday: {}
 	};
 
 	// Add a new workload pool to the list.
@@ -459,7 +459,7 @@
 						continue;
 					}
 
-					Object.defineProperty(dow, day.toLowerCase(), {
+					Object.defineProperty(dow, day, {
 						enumerable: true,
 						value: {
 							start: o.start,
@@ -601,8 +601,8 @@
 							{#if autoUpgradeDaysOfWeek}
 								{#each Object.keys(daysOfTheWeekWindows) as day}
 									<TimeWindowField
-										id="autoupgrade-{day.toLowerCase()}"
-										label={day}
+										id="autoupgrade-{day}"
+										label="Enable {day}?"
 										bind:object={daysOfTheWeekWindows[day]}
 									/>
 								{/each}
@@ -818,6 +818,14 @@
 		flex-direction: column;
 		align-items: stretch;
 		padding: var(--padding);
+		gap: var(--padding);
+	}
+	.autoupgrade {
+		padding: var(--padding);
+		border: 1px solid var(--brand);
+		align-items: stretch;
+		display: flex;
+		flex-direction: column;
 		gap: var(--padding);
 	}
 	.workloadpool {

--- a/src/lib/CreateControlPlaneModal.svelte
+++ b/src/lib/CreateControlPlaneModal.svelte
@@ -39,13 +39,13 @@
 	let autoUpgradeDaysOfWeek = false;
 
 	let daysOfTheWeekWindows = {
-		Sunday: {},
-		Monday: {},
-		Tuesday: {},
-		Wednesday: {},
-		Thursday: {},
-		Friday: {},
-		Saturday: {}
+		sunday: {},
+		monday: {},
+		tuesday: {},
+		wednesday: {},
+		thursday: {},
+		friday: {},
+		saturday: {}
 	};
 
 	function reset() {
@@ -159,7 +159,7 @@
 						continue;
 					}
 
-					Object.defineProperty(dow, day.toLowerCase(), {
+					Object.defineProperty(dow, day, {
 						enumerable: true,
 						value: {
 							start: o.start,
@@ -245,8 +245,8 @@
 						{#if autoUpgradeDaysOfWeek}
 							{#each Object.keys(daysOfTheWeekWindows) as day}
 								<TimeWindowField
-									id="autoupgrade-{day.toLowerCase()}"
-									label={day}
+									id="autoupgrade-{day}"
+									label="Enable {day}?"
 									bind:object={daysOfTheWeekWindows[day]}
 								/>
 							{/each}

--- a/src/lib/TimeWindowField.svelte
+++ b/src/lib/TimeWindowField.svelte
@@ -6,11 +6,19 @@
 	export let id;
 	export let label;
 
+	export let existing = null;
+
 	export let enabled = false;
 	export let start = 0;
 	export let end = 7;
 
 	export let object;
+
+	if (existing) {
+		enabled = true;
+		start = existing.start;
+		end = existing.end;
+	}
 
 	$: {
 		object = {


### PR DESCRIPTION
Allow time-of day tags to accept an existing configuration, then add it to the edit dialogs.  All too easy... which is suspicious!