### PR TITLE
Await Project Creation

### DIFF
--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import { token } from '$lib/credentials.js';
+	import { errors } from '$lib/errors.js';
 	import { createEventDispatcher } from 'svelte';
 
 	import {
@@ -541,6 +542,11 @@
 
 		await createCluster(controlPlane.name, {
 			token: token.get().token,
+			onBadRequest: (message) => {
+				if (message) {
+					errors.add(message);
+				}
+			},
 			onUnauthorized: () => {
 				token.remove();
 			},

--- a/src/lib/EditClusterModal.svelte
+++ b/src/lib/EditClusterModal.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import { token } from '$lib/credentials.js';
+	import { errors } from '$lib/errors.js';
 	import { createEventDispatcher } from 'svelte';
 
 	import {
@@ -524,6 +525,11 @@
 
 		await updateCluster(controlPlane.name, cluster.name, {
 			token: token.get().token,
+			onBadRequest: (message) => {
+				if (message) {
+					errors.add(message);
+				}
+			},
 			onUnauthorized: () => {
 				token.remove();
 			},

--- a/src/lib/EditControlPlaneModal.svelte
+++ b/src/lib/EditControlPlaneModal.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
 	import { token } from '$lib/credentials.js';
+	import { errors } from '$lib/errors.js';
 	import { createEventDispatcher } from 'svelte';
 
 	import { updateControlPlane, listApplicationBundlesControlPlane } from '$lib/client.js';
@@ -152,8 +153,10 @@
 		await updateControlPlane(controlPlane.name, {
 			token: token.get().token,
 			body: body,
-			onBadRequest: () => {
-				console.log('you have made a mistake');
+			onBadRequest: (message) => {
+				if (message) {
+					errors.add(message);
+				}
 			},
 			onUnauthorized: () => {
 				token.remove();

--- a/src/lib/Errors.svelte
+++ b/src/lib/Errors.svelte
@@ -1,0 +1,66 @@
+<script>
+	import { onMount, onDestroy } from 'svelte';
+	import { errors } from '$lib/errors.js';
+
+	let list = [];
+	let unsubscribe = null;
+
+	function update(value) {
+		list = value;
+	}
+
+	onMount(() => {
+		unsubscribe = errors.subscribe(update);
+	});
+
+	onDestroy(() => {
+		if (unsubscribe) {
+			unsubscribe();
+		}
+	});
+
+	function remove(index) {
+		errors.remove(index);
+	}
+</script>
+
+{#if list.length > 0}
+	<div class="errorlist">
+		{#each list as error, index}
+			<div class="erroritem">
+				<iconify-icon icon="mdi:error-outline" />
+				<div class="errortext">
+					{error}
+				</div>
+				<iconify-icon
+					class="selectable"
+					icon="mdi:close"
+					on:click={() => remove(index)}
+					on:keypress={() => remove(index)}
+				/>
+			</div>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.errorlist {
+		display: flex;
+		flex-direction: column;
+	}
+	.erroritem {
+		color: white;
+		background-color: var(--error);
+		display: flex;
+		align-items: center;
+		gap: var(--padding);
+		padding: var(--padding);
+	}
+	.errortext {
+		flex: 1;
+		font-weight: bold;
+	}
+	iconify-icon {
+		font-size: 1.5rem;
+	}
+</style>

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -18,23 +18,40 @@ async function request(method, path, opts) {
 
 		const response = await fetch(path, options);
 
+		const contentType = response.headers.get('Content-Type');
+
 		if (!response.ok) {
+			let message = null;
+
+			if (contentType == 'application/json') {
+				let error = await response.json();
+
+				message = `Error: ${error.error}, Description: ${error.error_description}`;
+			}
+
 			if (response.status == 400 && opts.onBadRequest) {
-				opts.onBadRequest();
+				opts.onBadRequest(message);
 			} else if (response.status == 401 && opts.onUnauthorized) {
-				opts.onUnauthorized();
+				opts.onUnauthorized(message);
 			} else if (response.status == 404 && opts.onNotFound) {
-				opts.onNotFound();
+				opts.onNotFound(message);
 			} else if (response.status == 409 && opts.onConflict) {
-				opts.onConflict();
+				opts.onConflict(message);
 			} else {
-				console.log('unhandled status', response.status, 'method', method, 'path', path);
+				console.log(
+					'unhandled status',
+					response.status,
+					'method',
+					method,
+					'path',
+					path,
+					'message',
+					message
+				);
 			}
 
 			return null;
 		}
-
-		const contentType = response.headers.get('Content-Type');
 
 		if (contentType == null) {
 			return null;
@@ -102,6 +119,10 @@ export function listExternalNetworks(opts) {
 
 export function createProject(opts) {
 	return request('POST', `/api/v1/project`, opts);
+}
+
+export function getProject(opts) {
+	return request('GET', `/api/v1/project`, opts);
 }
 
 export function listControlPlanes(opts) {

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,25 @@
+import { writable } from 'svelte/store';
+
+export const errors = init();
+
+function init() {
+	const list = [];
+
+	const errors = writable(list);
+
+	function add(message) {
+		list.push(message);
+		errors.set(list);
+	}
+
+	function remove(index) {
+		list.splice(index, 1);
+		errors.set(list);
+	}
+
+	return {
+		subscribe: errors.subscribe,
+		add: add,
+		remove: remove
+	};
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,7 @@
 	import DashboardView from '$lib/DashboardView.svelte';
 	import ControlPlaneView from '$lib/ControlPlaneView.svelte';
 	import ClusterView from '$lib/ClusterView.svelte';
+	import Errors from '$lib/Errors.svelte';
 
 	let showmenu = false;
 
@@ -186,6 +187,7 @@
 
 <main class:showmenu>
 	<Breadcrumbs />
+	<Errors />
 	{#if content == 'dashboard'}
 		<DashboardView />
 	{:else if content == 'kubernetes-control-planes'}


### PR DESCRIPTION
The initial problem is that it creates a project, then expects it to be immediately available, so the subsequent CP creation can actually fail. Silently.  So first up add in a simple error notification banner that can be dismissed.  Next up, when creating the project, block CP creation until the project reports as provisioned, lest server reject the creation request.