### PR TITLE
Handle Application Credential Permissions

### DIFF
--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -416,12 +416,18 @@
 			onUnauthorized: () => {
 				token.remove();
 			},
+			onForbidden: (message) => {
+				if (message) {
+					errors.add(message);
+				}
+			},
 			body: {
 				name: appCredName(name)
 			}
 		});
 
 		if (ac == null) {
+			active = false;
 			return;
 		}
 

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -33,6 +33,8 @@ async function request(method, path, opts) {
 				opts.onBadRequest(message);
 			} else if (response.status == 401 && opts.onUnauthorized) {
 				opts.onUnauthorized(message);
+			} else if (response.status == 403 && opts.onForbidden) {
+				opts.onForbidden(message);
 			} else if (response.status == 404 && opts.onNotFound) {
 				opts.onNotFound(message);
 			} else if (response.status == 409 && opts.onConflict) {


### PR DESCRIPTION
We need to support the 403 error that can be returned when creating application credentials when the user lacks the correct roles.  Then we need to expose this error in a userful manner to the user, rather than silently dying.