### PR TITLE
Add Kubernetes Dashboard

### DIFF
--- a/src/lib/CheckBoxField.svelte
+++ b/src/lib/CheckBoxField.svelte
@@ -10,10 +10,13 @@
 
 	// help text.
 	export let help;
+
+	// disable the input.
+	export let disabled = false;
 </script>
 
 <div class="checkbox">
-	<input {id} type="checkbox" bind:checked />
+	<input {id} type="checkbox" bind:checked {disabled} />
 	<span>{label}</span>
 </div>
 <label for={id} class="fieldlabel">{@html help}</label>

--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -88,6 +88,11 @@
 	let autoscaling = false;
 	let ingress = false;
 	let certManager = false;
+	let kubernetesDashboard = false;
+
+	$: if (kubernetesDashboard) {
+		ingress = certManager = true;
+	}
 
 	// A set of workload pools for the cluster.
 	let workloadPools = [];
@@ -517,6 +522,10 @@
 			if (certManager) {
 				body.features.certManager = true;
 			}
+
+			if (kubernetesDashboard) {
+				body.features.kubernetesDashboard = true;
+			}
 		}
 
 		for (const wp of workloadPools) {
@@ -757,6 +766,7 @@
 						label="Enable ingress controller?"
 						help="Enables Nginx ingress controller"
 						bind:checked={ingress}
+						disabled={kubernetesDashboard}
 					/>
 
 					<CheckBoxField
@@ -764,6 +774,15 @@
 						label="Enable cert-manager controller?"
 						help="Enables cert-manager TLS certificate management controller"
 						bind:checked={certManager}
+						disabled={kubernetesDashboard}
+					/>
+
+					<CheckBoxField
+						id="kubernetes-dashboard"
+						label="Enable Kubernetes dashboard?"
+						help="Enables Kubernetes dashboard, automatically require
+s ingress and cert-manager add-ons"
+						bind:checked={kubernetesDashboard}
 					/>
 				</section>
 			</details>

--- a/src/lib/EditClusterModal.svelte
+++ b/src/lib/EditClusterModal.svelte
@@ -106,6 +106,11 @@
 	let autoscaling = cluster.features && cluster.features.autoscaling;
 	let ingress = cluster.features && cluster.features.ingress;
 	let certManager = cluster.features && cluster.features.certManager;
+	let kubernetesDashboard = cluster.features && cluster.features.kubernetesDashboard;
+
+	$: if (kubernetesDashboard) {
+		ingress = certManager = true;
+	}
 
 	let workloadPools = [];
 
@@ -502,6 +507,18 @@
 			}
 		}
 
+		if (kubernetesDashboard) {
+			if (!body.features) {
+				body.features = {};
+			}
+
+			body.features.kubernetesDashboard = true;
+		} else {
+			if (body.features) {
+				delete body.features.kubernetesDashboard;
+			}
+		}
+
 		for (const p of workloadPools) {
 			const wp = p.object;
 
@@ -701,6 +718,7 @@
 						label="Enable ingress controller?"
 						help="Enables Nginx ingress controller"
 						bind:checked={ingress}
+						disabled={kubernetesDashboard}
 					/>
 
 					<CheckBoxField
@@ -708,6 +726,14 @@
 						label="Enable cert-manager controller?"
 						help="Enables cert-manager TLS certificate management controller"
 						bind:checked={certManager}
+						disabled={kubernetesDashboard}
+					/>
+
+					<CheckBoxField
+						id="kubernetes-dashboard"
+						label="Enable Kubernetes dashboard?"
+						help="Enables Kubernetes dashboard, automatically requires ingress and cert-manager add-ons"
+						bind:checked={kubernetesDashboard}
 					/>
 				</section>
 			</details>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -279,6 +279,9 @@
 		height: 1.5em;
 		border: 2px solid var(--brand);
 	}
+	:global(input[type='checkbox']:disabled) {
+		border: 2px solid var(--mid-grey);
+	}
 	:global(input[type='checkbox']::before) {
 		content: '';
 		width: 0.75em;
@@ -286,6 +289,9 @@
 		transform: scale(0);
 		transition: all 0.2s ease-in;
 		background-color: var(--brand);
+	}
+	:global(input[type='checkbox']:disabled::before) {
+		background-color: var(--mid-grey);
 	}
 	:global(input[type='checkbox']:checked::before) {
 		transform: scale(1);


### PR DESCRIPTION
Fairly straight forward, but we need to ensure when the dash is included, so are the ingress and cert-manager components, and they cannot be disabled.