### PR TITLE
Fix Upgrade Indicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"dependencies": {
 				"@sveltejs/adapter-node": "^1.2.0",
 				"crypto-js": "^4.1.1",
-				"jose": "^4.14.4"
+				"jose": "^4.14.4",
+				"semver": "^7.5.1"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^2.0.0",
@@ -1559,6 +1560,17 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
@@ -1961,6 +1973,20 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/semver": {
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
@@ -2237,6 +2263,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
@@ -3263,6 +3294,14 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
 		"magic-string": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
@@ -3506,6 +3545,14 @@
 				"mri": "^1.1.0"
 			}
 		},
+		"semver": {
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
+		},
 		"set-cookie-parser": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
@@ -3674,6 +3721,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	"dependencies": {
 		"@sveltejs/adapter-node": "^1.2.0",
 		"crypto-js": "^4.1.1",
-		"jose": "^4.14.4"
+		"jose": "^4.14.4",
+		"semver": "^7.5.1"
 	}
 }

--- a/src/lib/ClusterView.svelte
+++ b/src/lib/ClusterView.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { onDestroy } from 'svelte';
+	import { lt } from 'semver';
 	import { browser } from '$app/environment';
 	import { token, removeCredentials } from '$lib/credentials.js';
 	import { age } from '$lib/time.js';
@@ -98,7 +99,7 @@
 		}
 
 		for (const cluster of result) {
-			if (cluster.applicationBundle.name != bundles[0].name) {
+			if (lt(cluster.applicationBundle.version, bundles[0].version)) {
 				cluster.upgradable = true;
 			}
 		}

--- a/src/lib/ControlPlaneView.svelte
+++ b/src/lib/ControlPlaneView.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { onDestroy } from 'svelte';
+	import { lt } from 'semver';
 	import { token, removeCredentials } from '$lib/credentials.js';
 	import { age } from '$lib/time.js';
 	import {
@@ -68,7 +69,7 @@
 		}
 
 		for (const cp of result) {
-			if (cp.applicationBundle.name != bundles[0].name) {
+			if (lt(cp.applicationBundle.version, bundles[0].version)) {
 				cp.upgradable = true;
 			}
 		}


### PR DESCRIPTION
When we select "valid" bundles for clusters and control planes, we filter out the EoL and preview ones.  The check used to ask "am I at the most recent version" i.e. the top of the list.  This led to a false positive where a preview version would flag being upgradable erroneously.  Switch to using semver and do a < check for upgradability.