### PR TITLE
Make Upstream Options Optional

### DIFF
--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -3,6 +3,7 @@
 	import { token, removeCredentials } from '$lib/credentials.js';
 	import { errors } from '$lib/errors.js';
 	import { createEventDispatcher } from 'svelte';
+	import { gte } from 'semver';
 
 	import {
 		listFlavors,
@@ -802,19 +803,21 @@ s ingress and cert-manager add-ons"
 						bind:checked={kubernetesDashboard}
 					/>
 
-					<CheckBoxField
-						id="file-storage"
-						label="Enable file storage?"
-						help="Enables POSIX file based persistent storage"
-						bind:checked={fileStorage}
-					/>
+					{#if gte(applicationBundle.version, '1.3.0')}
+						<CheckBoxField
+							id="file-storage"
+							label="Enable file storage?"
+							help="Enables POSIX file based persistent storage"
+							bind:checked={fileStorage}
+						/>
 
-					<CheckBoxField
-						id="prometheus"
-						label="Enable Prometheus?"
-						help="Enables the Prometheus operator that can be used to provide platform monitoring"
-						bind:checked={prometheus}
-					/>
+						<CheckBoxField
+							id="prometheus"
+							label="Enable Prometheus?"
+							help="Enables the Prometheus operator that can be used to provide platform monitoring"
+							bind:checked={prometheus}
+						/>
+					{/if}
 				</section>
 			</details>
 

--- a/src/lib/EditClusterModal.svelte
+++ b/src/lib/EditClusterModal.svelte
@@ -3,6 +3,7 @@
 	import { token, removeCredentials } from '$lib/credentials.js';
 	import { errors } from '$lib/errors.js';
 	import { createEventDispatcher } from 'svelte';
+	import { gte } from 'semver';
 
 	import {
 		listFlavors,
@@ -688,19 +689,21 @@
 						bind:checked={kubernetesDashboard}
 					/>
 
-					<CheckBoxField
-						id="file-storage"
-						label="Enable file storage?"
-						help="Enables POSIX file based persistent storage"
-						bind:checked={fileStorage}
-					/>
+					{#if gte(applicationBundle.version, '1.3.0')}
+						<CheckBoxField
+							id="file-storage"
+							label="Enable file storage?"
+							help="Enables POSIX file based persistent storage"
+							bind:checked={fileStorage}
+						/>
 
-					<CheckBoxField
-						id="prometheus"
-						label="Enable Prometheus?"
-						help="Enables the Prometheus operator that can be used to provide platform monitoring"
-						bind:checked={prometheus}
-					/>
+						<CheckBoxField
+							id="prometheus"
+							label="Enable Prometheus?"
+							help="Enables the Prometheus operator that can be used to provide platform monitoring"
+							bind:checked={prometheus}
+						/>
+					{/if}
 				</section>
 			</details>
 


### PR DESCRIPTION
Longhorn and prometheus are introduced in 1.3.0, so don't display those options unless that's the selected bundle.