### PR TITLE
Move Application Credentials into Server

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -99,14 +99,6 @@ export function listKeyPairs(opts) {
 	return request('GET', '/api/v1/providers/openstack/key-pairs', opts);
 }
 
-export function createApplicationCredential(opts) {
-	return request('POST', '/api/v1/providers/openstack/application-credentials', opts);
-}
-
-export function deleteApplicationCredential(name, opts) {
-	return request('DELETE', `/api/v1/providers/openstack/application-credentials/${name}`, opts);
-}
-
 export function getServerGroup(name, opts) {
 	return request('GET', `/api/v1/providers/openstack/servergroups/${name}`, opts);
 }


### PR DESCRIPTION
Having the client manage these is extra work for the client, plus the application credential secret traverses the public internet twice. Doing this as part of Server not only makes it more secure, but also improves in the interface.