### PR TITLE
Implicit Child Object Creation

### DIFF
--- a/src/lib/ControlPlaneView.svelte
+++ b/src/lib/ControlPlaneView.svelte
@@ -84,7 +84,7 @@
 			return 'progressing';
 		} else if (status.status == 'Provisioned') {
 			return 'ok';
-		} else if (['Provisioning', 'Deprovisioning', 'Updating'].includes(status.status)) {
+		} else if (['Provisioning', 'Deprovisioning'].includes(status.status)) {
 			return 'progressing';
 		} else if (['Unknown', 'Cancelled'].includes(status.status)) {
 			return 'warning';

--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -46,6 +46,8 @@
 	// We will raise clusterCreated on successful cluster creation.
 	const dispatch = createEventDispatcher();
 
+	let submitting = false;
+
 	// name of the cluster.
 	let name = null;
 	let nameValid = false;
@@ -405,6 +407,8 @@
 	$: valid = [nameValid].every((x) => x) && hasWorkloadPools && workloadPools.every((x) => x.valid);
 
 	async function submit() {
+		submitting = true;
+
 		const body = {
 			name: name,
 			applicationBundle: applicationBundle,
@@ -517,7 +521,13 @@
 			body.workloadPools.push(pool);
 		}
 
-		await createCluster(controlPlane.name, {
+		let controlPlaneName = 'default';
+
+		if (controlPlane) {
+			controlPlaneName = controlPlane.name;
+		}
+
+		await createCluster(controlPlaneName, {
 			token: accessToken,
 			onBadRequest: (message) => {
 				if (message) {
@@ -844,10 +854,17 @@ s ingress and cert-manager add-ons"
 			</button>
 
 			<div class="buttons">
-				<button type="submit" disabled={!valid} on:click={submit} on:keydown={submit}>
-					<iconify-icon icon="mdi:tick" />
-					<div>Create</div>
-				</button>
+				{#if submitting}
+					<button disabled="true">
+						<iconify-icon icon="svg-spinners:ring-resize" />
+						<div>Creating...</div>
+					</button>
+				{:else}
+					<button type="submit" disabled={!valid} on:click={submit} on:keydown={submit}>
+						<iconify-icon icon="mdi:tick" />
+						<div>Create</div>
+					</button>
+				{/if}
 				<button on:click={close}>
 					<iconify-icon icon="mdi:close" />
 					<div>Cancel</div>

--- a/src/lib/EditClusterModal.svelte
+++ b/src/lib/EditClusterModal.svelte
@@ -45,6 +45,8 @@
 	// We will raise clusterCreated on successful cluster creation.
 	const dispatch = createEventDispatcher();
 
+	let submitting = false;
+
 	// Define dynamic things from the API.
 	let versions = [];
 	let allImages = [];
@@ -404,6 +406,8 @@
 	$: changeWorkloadPools(workloadPools);
 
 	async function submit() {
+		submitting = true;
+
 		// Deep copy the object, bad tends to happen when you mutate
 		// something non-local.
 		let body = JSON.parse(JSON.stringify(cluster));
@@ -814,10 +818,17 @@
 			</button>
 
 			<div class="buttons">
-				<button type="submit" disabled={!valid} on:click={submit} on:keydown={submit}>
-					<iconify-icon icon="mdi:tick" />
-					<div>Update</div>
-				</button>
+				{#if submitting}
+					<button disabled="true">
+						<iconify-icon icon="svg-spinners:ring-resize" />
+						<div>Creating...</div>
+					</button>
+				{:else}
+					<button type="submit" disabled={!valid} on:click={submit} on:keydown={submit}>
+						<iconify-icon icon="mdi:tick" />
+						<div>Update</div>
+					</button>
+				{/if}
 				<button on:click={close} on:keydown={close}>
 					<iconify-icon icon="mdi:close" />
 					<div>Cancel</div>

--- a/src/lib/EditControlPlaneModal.svelte
+++ b/src/lib/EditControlPlaneModal.svelte
@@ -22,6 +22,8 @@
 	// We will raise controlPlaneUpdated on successful cluster update.
 	const dispatch = createEventDispatcher();
 
+	let submitting = false;
+
 	let accessToken;
 
 	// Control plane versioning support.
@@ -110,6 +112,8 @@
 	}
 
 	async function submit() {
+		submitting = true;
+
 		// Deep copy the object, bad tends to happen when you mutate
 		// something non-local.
 		let body = JSON.parse(JSON.stringify(controlPlane));
@@ -229,10 +233,17 @@
 		</details>
 
 		<div class="buttons">
-			<button type="submit" on:click={submit} on:keydown={submit}>
-				<iconify-icon icon="mdi:tick" />
-				<div>Update</div>
-			</button>
+			{#if submitting}
+				<button disabled="true">
+					<iconify-icon icon="svg-spinners:ring-resize" />
+					<div>Creating...</div>
+				</button>
+			{:else}
+				<button type="submit" on:click={submit} on:keydown={submit}>
+					<iconify-icon icon="mdi:tick" />
+					<div>Create</div>
+				</button>
+			{/if}
 			<button on:click={close}>
 				<iconify-icon icon="mdi:close" />
 				<div>Cancel</div>

--- a/src/lib/StatusIcon.svelte
+++ b/src/lib/StatusIcon.svelte
@@ -9,7 +9,7 @@
 {:else if status == 'error'}
 	<iconify-icon class="error" icon="mdi:error-outline" />
 {:else if status == 'progressing'}
-	<iconify-icon class="progressing" icon="mdi:circle-arrows" />
+	<iconify-icon class="progressing" icon="svg-spinners:ring-resize" />
 {:else}
 	<iconify-icon class="unknown" icon="mdi:question-mark" />
 {/if}
@@ -29,20 +29,8 @@
 	}
 	.progressing {
 		color: var(--mid-grey);
-		animation-name: spin;
-		animation-duration: 5000ms;
-		animation-iteration-count: infinite;
-		animation-timing-function: linear;
 	}
 	iconify-icon {
 		font-size: var(--icon-size);
-	}
-	@keyframes spin {
-		from {
-			transform: rotate(0deg);
-		}
-		to {
-			transform: rotate(360deg);
-		}
 	}
 </style>


### PR DESCRIPTION
Server has been modified to implicitly create projects and control planes, so we don't necessarily need to do it in the UI any more.  The hard bit in this instance is updaing the cluster view as control planes were static, and can now appear during the life time of the view (and by extension disappear possibly).  Tweak it so that a refresh does the control planes, that will implicitly trigger a cluster update.  Also add some logic to make the "submit" buttons go inactive on click and show a spinner, and various other usability tweaks.