### PR TITLE
Use Google Distroless Images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+charts
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM node:19-alpine
+FROM node:20-alpine as build
 
-WORKDIR /usr/src/app
-
-COPY package.json package-lock.json .
-RUN npm install
+WORKDIR /app
 
 COPY . .
-RUN npm run build
 
-# Run as the node user.
-USER 1000
+RUN npm install \
+ && npm run build
 
-ENTRYPOINT ["node", "build"]
+FROM gcr.io/distroless/nodejs20:nonroot
+
+COPY --from=build /app /app
+WORKDIR /app
+
+CMD ["build"]


### PR DESCRIPTION
They do things like install a non-root user and CA certificates for us, which is always a benefit.  Also this does lead to a 30MB saving, which is never a bad thing.