### PR TITLE
Version 0.1.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spec:
   source:
     path: charts/unikorn-ui
     repoURL: git@github.com:eschercloudai/unikorn-ui
-    targetRevision: 0.1.30
+    targetRevision: 0.1.31
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn-ui/Chart.yaml
+++ b/charts/unikorn-ui/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: 0.1.30
-appVersion: 0.1.30
+version: 0.1.31
+appVersion: 0.1.31
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -117,10 +117,6 @@ export function createProject(opts) {
 	return request('POST', `/api/v1/project`, opts);
 }
 
-export function getProject(opts) {
-	return request('GET', `/api/v1/project`, opts);
-}
-
 export function listControlPlanes(opts) {
 	return request('GET', '/api/v1/controlplanes', opts);
 }

--- a/src/lib/localStorage.js
+++ b/src/lib/localStorage.js
@@ -3,11 +3,14 @@ import { browser } from '$app/environment';
 
 // localStorage wraps a Svelte store and persists the value in persistent storage.
 // The initial value comes from persistent storage.
-export function localStorage(key) {
-	let value;
+export function localStorage(key, defaultValue) {
+	let value = defaultValue;
 
 	if (browser) {
-		value = window.localStorage.getItem(key);
+		const storageValue = window.localStorage.getItem(key);
+		if (storageValue != null) {
+			value = storageValue;
+		}
 	}
 
 	const store = writable(value);


### PR DESCRIPTION
Hotfix to spot when a menu ID is no-longer valid, and reset it to a known good default value.  Checked that:

* works when no values are set e.g. first use
* works when an illegal value is set