### PR TITLE
Fix Scoping Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ spec:
   source:
     path: charts/unikorn-ui
     repoURL: git@github.com:eschercloudai/unikorn-ui
-    targetRevision: 0.1.33
+    targetRevision: 0.1.34
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn-ui/Chart.yaml
+++ b/charts/unikorn-ui/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn UI
 
 type: application
 
-version: 0.1.33
-appVersion: 0.1.33
+version: 0.1.34
+appVersion: 0.1.34
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "unikorn-ui",
-	"version": "0.1.33",
+	"version": "0.1.34",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/src/lib/ClusterView.svelte
+++ b/src/lib/ClusterView.svelte
@@ -37,6 +37,13 @@
 	});
 
 	function changeToken(value) {
+		// If the token changes, then we need to purge the control plane at least
+		// as that will trigger a refresh of the clusters, and doing so may provision
+		// an existing control plane in the new project.
+		controlPlanes = [];
+		controlPlane = null;
+		clusters = [];
+
 		accessToken = value;
 	}
 


### PR DESCRIPTION
When the project scope changes in the cluster view, there is a race condition where the list of clusters can get updated before the list of control planes.  This causes a list operation, which will implictly create a control plane, based on the old scope, in the new project.  We need to purge the old control plane before updating anything based on the new token so it isn't magically auto-provisioned.