### PR TITLE
Tweak Dropdown Styles

### DIFF
--- a/src/lib/DropDownItem.svelte
+++ b/src/lib/DropDownItem.svelte
@@ -21,7 +21,6 @@
 		display: flex;
 		align-items: center;
 		gap: var(--padding);
-		color: var(--dark-grey);
 		padding: var(--padding);
 		list-style: none;
 		transition: all 0.3s ease-in-out;


### PR DESCRIPTION
Make them visible, e.g. just use the inherited clour rather than overriding it.