### PR TITLE
PoC Item Details

### DIFF
--- a/src/lib/ApplicationView.svelte
+++ b/src/lib/ApplicationView.svelte
@@ -11,6 +11,8 @@
 
 	let applications = [];
 
+	let selected = null;
+
 	const tokenUnsubscribe = token.subscribe(changeToken);
 
 	const ticker = setInterval(() => updateApplictions(accessToken), 10000);
@@ -38,16 +40,26 @@
 				removeCredentials();
 			}
 		});
+
+		if (selected) {
+			const results = applications.filter((x) => x.name == selected.name);
+
+			selected = results[0];
+		}
 	}
 
 	$: updateApplictions(accessToken);
+
+	function select(app) {
+		selected = selected == app ? null : app;
+	}
 </script>
 
 <View>
 	<ItemView>
 		{#each applications as app}
-			<Item>
-				<div class="image-wrapper">
+			<Item selected={app == selected}>
+				<div class="image-wrapper" on:click={select(app)} on:keypress={select(app)}>
 					{@html atob(app.icon)}
 				</div>
 				<dl>
@@ -55,10 +67,21 @@
 					<dd>{app.humanReadableName}</dd>
 					<dt>Version</dt>
 					<dd>{app.version}</dd>
-					<dt>License</dt>
-					<dd>{app.license}</dd>
 				</dl>
 			</Item>
+			{#if app == selected}
+				<Item jumbo="true" selected="true">
+					<h3>Application Details</h3>
+					<dl>
+						<dt>Description</dt>
+						<dd>{app.description}</dd>
+						<dt>Documentation</dt>
+						<dd><a href={app.documentation}>{app.documentation}</a></dd>
+						<dt>License</dt>
+						<dd>{app.license}</dd>
+					</dl>
+				</Item>
+			{/if}
 		{/each}
 	</ItemView>
 </View>

--- a/src/lib/Breadcrumbs.svelte
+++ b/src/lib/Breadcrumbs.svelte
@@ -21,12 +21,15 @@
 <style>
 	ul {
 		color: white;
-		background-color: var(--brand-dark);
+		background-color: var(--overlay-brand);
 		display: flex;
 		align-items: center;
 		gap: 1.25em;
 		overflow-x: auto;
-		min-height: 2em;
+		min-height: 2.5em;
+		border-top: 1px solid var(--brand);
+		border-bottom: 1px solid var(--brand);
+		box-sizing: content-box;
 	}
 
 	li {

--- a/src/lib/Item.svelte
+++ b/src/lib/Item.svelte
@@ -1,4 +1,10 @@
-<article class="item">
+<script>
+	export let jumbo = false;
+
+	export let selected = false;
+</script>
+
+<article class="item" class:jumbo class:selected>
 	<slot />
 </article>
 
@@ -12,5 +18,13 @@
 		border-radius: var(--radius);
 		box-shadow: 0 0 var(--radius) var(--brand-light);
 		padding: var(--padding);
+	}
+
+	.jumbo {
+		grid-column: 1 / -1;
+	}
+
+	.selected {
+		background: var(--overlay-brand);
 	}
 </style>

--- a/src/lib/ItemView.svelte
+++ b/src/lib/ItemView.svelte
@@ -16,6 +16,7 @@
 		.items {
 			display: grid;
 			grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+			grid-auto-flow: dense;
 		}
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -232,6 +232,7 @@
 		--nav-width: 100vw;
 
 		--overlay: rgba(240, 230, 230, 0.95);
+		--overlay-brand: rgba(234, 218, 236, 0.95);
 		--modal: rgb(255, 255, 255);
 	}
 
@@ -497,6 +498,7 @@
 	@media (prefers-color-scheme: dark) {
 		:global(:root) {
 			--overlay: rgba(40, 40, 40, 0.75);
+			--overlay-brand: rgba(50, 33, 51, 0.75);
 			--modal: rgb(13, 13, 28);
 		}
 		:global(body) {


### PR DESCRIPTION
Items are typically displayed in a grid, therefore for it not to look shambolic, all things should be sized the same, which limits us to fixed content.  For other things that are variable, or just irrelevant, we should be able to diplsay them in a free-form item.  Now we could mess about with modals, but actually it transpires putting them into the grid as a full width entry is a way better UX as you can click between items.