### PR TITLE
Add Variables

### DIFF
--- a/charts/unikorn-ui/templates/unikorn-ui.yaml
+++ b/charts/unikorn-ui/templates/unikorn-ui.yaml
@@ -60,6 +60,15 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
+        env:
+        - name: PUBLIC_APPLICATION_VERSION
+          value: {{ .Chart.Version }}
+        - name: PUBLIC_NODE_PREFIX
+          value: {{ .Values.nodePrefix }}
+        - name: PUBLIC_SERVICE_PREFIX
+          value: {{ .Values.servicePrefix }}
+        - name: PUBLIC_POD_PREFIX
+          value: {{ .Values.podPrefix }}
         securityContext:
           readOnlyRootFilesystem: true
       serviceAccountName: unikorn-ui

--- a/charts/unikorn-ui/values.yaml
+++ b/charts/unikorn-ui/values.yaml
@@ -21,3 +21,12 @@ imagePullSecret:
 
 # Allows override of the global default image.
 image:
+
+# Default node prefix.
+nodePrefix: 192.168.0.0/24
+
+# Default service prefix.
+servicePrefix: 172.16.0.0/12
+
+# Default pod prefix.
+podPrefix: 10.0.0.0/8

--- a/src/lib/CreateClusterModal.svelte
+++ b/src/lib/CreateClusterModal.svelte
@@ -3,6 +3,7 @@
 	import { token, removeCredentials } from '$lib/credentials.js';
 	import { errors } from '$lib/errors.js';
 	import { createEventDispatcher } from 'svelte';
+	import { env } from '$env/dynamic/public';
 
 	import {
 		listFlavors,
@@ -88,6 +89,10 @@
 	let dnsNameservers;
 	let allowedPrefixes;
 	let sans;
+
+	let defaultNodePrefix = env.PUBLIC_NODE_PREFIX;
+	let defaultServicePrefix = env.PUBLIC_SERVICE_PREFIX;
+	let defaultPodPrefix = env.PUBLIC_POD_PREFIX;
 
 	// Whether the cluster-autoscaler add-on is provisioned.
 	let autoscaling = false;
@@ -418,9 +423,9 @@
 				externalNetworkID: externalNetworks[0].id
 			},
 			network: {
-				nodePrefix: nodePrefix ? nodePrefix : '192.168.0.0/16',
-				servicePrefix: servicePrefix ? servicePrefix : '172.16.0.0/12',
-				podPrefix: podPrefix ? podPrefix : '10.0.0.0/8',
+				nodePrefix: nodePrefix ? nodePrefix : defaultNodePrefix,
+				servicePrefix: servicePrefix ? servicePrefix : defaultServicePrefix,
+				podPrefix: podPrefix ? podPrefix : defaultPodPrefix,
 				dnsNameservers: dnsNameservers ? dnsNameservers.split(',') : ['8.8.8.8', '8.8.4.4']
 			},
 			controlPlane: {
@@ -682,21 +687,21 @@
 
 						<TextField
 							id="nodeNetwork"
-							placeholder="192.168.0.0/16"
+							placeholder={defaultNodePrefix}
 							help="IPv4 CIDR to run Kubernetes nodes in."
 							bind:value={nodePrefix}
 						/>
 
 						<TextField
 							id="podNetwork"
-							placeholder="10.0.0.0/8"
+							placeholder={defaultPodPrefix}
 							help="IPv4 CIDR to run Kubernets pods in."
 							bind:value={podPrefix}
 						/>
 
 						<TextField
 							id="serviceNetwork"
-							placeholder="172.16.0.0/12"
+							placeholder={defaultServicePrefix}
 							help="IPv4 CIDR to run Kubernetes services in."
 							bind:value={servicePrefix}
 						/>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import { token, email, project, updateCredentials, removeCredentials } from '$lib/credentials.js';
 	import { getMenu, selected } from '$lib/menu.js';
 	import { listProjects } from '$lib/client.js';
+	import { env } from '$env/dynamic/public';
 
 	import Menu from '$lib/Menu.svelte';
 	import LoginModal from '$lib/LoginModal.svelte';
@@ -192,6 +193,8 @@
 					<Menu {...menu} />
 				{/if}
 			</section>
+
+			<div class="about">Version {env.PUBLIC_APPLICATION_VERSION}</div>
 		</nav>
 
 		<main class:showmenu>
@@ -479,6 +482,12 @@
 	.user iconify-icon {
 		font-size: var(--icon-size);
 		color: var(--brand);
+	}
+
+	.about {
+		font-size: 0.8em;
+		color: var(--dark-grey);
+		text-align: center;
 	}
 
 	/* Desktop overrides */


### PR DESCRIPTION
Two very annoying things are getting fixed here.  First I never know the version, we want this to be propagated down from the chart.  Second, because our dev environment uses RFC1918 addresses for the public address subnet, we need to avoid these when spinning up clusters, which is a bit of a mare as twiddling them is time consuming.  Instead we can just push this into environment specific Helm configuration.