### PR TITLE
Fix Null Dereference

### DIFF
--- a/src/lib/ApplicationView.svelte
+++ b/src/lib/ApplicationView.svelte
@@ -34,12 +34,18 @@
 			return;
 		}
 
-		applications = await listApplications({
+		const result = await listApplications({
 			token: accessToken,
 			onUnauthorized: () => {
 				removeCredentials();
 			}
 		});
+
+		if (result == null) {
+			return;
+		}
+
+		applications = result;
 
 		if (selected) {
 			const results = applications.filter((x) => x.name == selected.name);


### PR DESCRIPTION
In the application view, handing a token expiry isn't doen properly and we end up setting the applications array to null, rather than correctly saving to a temporary variable and short cutting exit if null is returned from the promise.