### PR TITLE
Tweak User Styling

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -478,14 +478,13 @@
 		display: flex;
 		align-items: center;
 		gap: var(--padding);
-		justify-content: space-between;
 	}
 	.user span {
 		font-size: 0.8em;
+		flex-grow: 1;
 	}
 	.user img {
 		max-height: var(--nav-icon-size);
-		margin-right: var(--padding);
 		border-radius: 1em;
 		border: 1px solid currentColor;
 	}


### PR DESCRIPTION
Everything else is aligned left, this seems out of place being centred, but we want the logout icon to "float" right, so remove the justification and grow the middle bit to use up all the space.